### PR TITLE
Fix JavaCard DevKit extraction path

### DIFF
--- a/manage_applet.sh
+++ b/manage_applet.sh
@@ -128,7 +128,8 @@ check_dependencies() {
             red "Error: Failed to download JavaCard DevKit"
             exit 1
         fi
-        if ! unzip /tmp/java_card_devkit.zip -d $DEPS_PATH; then
+        mkdir -p "$JCDK_PATH"
+        if ! unzip /tmp/java_card_devkit.zip -d "$JCDK_PATH"; then
             red "Error: Failed to extract JavaCard DevKit"
             rm /tmp/java_card_devkit.zip
             exit 1


### PR DESCRIPTION
## Summary
- ensure JavaCard DevKit archive is extracted into `$HOME/java_card_devkit`

## Testing
- ⚠️ `shellcheck manage_applet.sh` (command not found, apt repositories forbidden)
- ⚠️ `pytest` (missing module `ledger_pluto`)


------
https://chatgpt.com/codex/tasks/task_e_68af6cf349388322bf418a9dcefe1a65